### PR TITLE
Send query time and total results to response

### DIFF
--- a/src/engines/__init__.py
+++ b/src/engines/__init__.py
@@ -12,7 +12,7 @@ class Engine(ABC):
         self.dataset = dataset
 
     @abstractmethod
-    def answer(self, query: str) -> QueryResults:
+    def answer(self, query: str, max_length: int) -> QueryResults:
         """Answers a query to the user."""
 
     @abstractmethod

--- a/src/engines/vectorial/vectorial.py
+++ b/src/engines/vectorial/vectorial.py
@@ -103,7 +103,7 @@ class VectorialModel(Engine):
 
         return {term: count / max_term for term, count in term_count.items()}
 
-    def answer(self, query: str) -> QueryResults:
+    def answer(self, query: str, max_length: int) -> QueryResults:
         query_terms = get_terms(query)
         query_ntf = VectorialModel._ntf(query_terms)
         query_idf: dict[str, float] = {}
@@ -120,7 +120,7 @@ class VectorialModel(Engine):
             for term in query_terms
         }
 
-        results = QueryResults(ranking=True)
+        results = QueryResults(ranking=True, max_length=max_length)
         with Session(self.engine) as session:
             for doc in session.exec(select(Document)):
                 sim = self._sim(query_weights, doc)

--- a/src/main.py
+++ b/src/main.py
@@ -34,11 +34,11 @@ def paginated(limit: int, offset: int, results: list, total: int):
     }
 
 
-def fetch_documents(q: str, dataset: Dataset.cranfield):
+def fetch_documents(q: str, dataset: Dataset, limit: int, offset: int):
     if dataset == Dataset.cranfield:
         model = VectorialModel(CranfieldParser())
 
-    results = model.answer(q)
+    results = model.answer(q, max_length=200)
     rank = { doc.id: doc.sim for doc in results.rank }
     ids = [result.id for result in results.docs]
 
@@ -51,7 +51,7 @@ def fetch_documents(q: str, dataset: Dataset.cranfield):
 @app.get("/query")
 async def query(q: str, dataset: Dataset = Dataset.cranfield, limit: int = 10, offset: int = 0):
     try:
-        (docs, time) = timed(fetch_documents, q, dataset)
+        (docs, time) = timed(fetch_documents, q, dataset, limit, offset)
         return { "query": q, "time": time } | paginated(limit, offset, docs[offset:offset + limit], len(docs))
             
     except Exception as e: # TODO: Remove this shitty exception handler by fixing empty results bug

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ def paginated(limit: int, offset: int, results: list, total: int):
         "results": results,
         "limit": limit,
         "offset": offset,
+        "total": total,
         "hasMore": offset + limit < total,
     }
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,4 @@
-from ast import In
 from enum import Enum
-from xml.etree.ElementInclude import include
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -9,6 +7,7 @@ from sqlmodel import Session
 from src.parsers import CranfieldParser
 from src.engines.vectorial.vectorial import VectorialModel
 from src.engines.models import Document
+from src.utils.timeit import timed
 
 
 app = FastAPI()
@@ -34,22 +33,26 @@ def paginated(limit: int, offset: int, results: list, total: int):
     }
 
 
+def fetch_documents(q: str, dataset: Dataset.cranfield):
+    if dataset == Dataset.cranfield:
+        model = VectorialModel(CranfieldParser())
+
+    results = model.answer(q)
+    rank = { doc.id: doc.sim for doc in results.rank }
+    ids = [result.id for result in results.docs]
+
+    with Session(model.engine) as session:
+        docs = session.query(Document).filter(Document.id.in_(ids)).all()
+        docs = sorted(docs, key=lambda doc: rank[doc.id], reverse=True)
+
+    return docs
+
 @app.get("/query")
 async def query(q: str, dataset: Dataset = Dataset.cranfield, limit: int = 10, offset: int = 0):
     try:
-        if dataset == Dataset.cranfield:
-            model = VectorialModel(CranfieldParser())
-
-        results = model.answer(q)
-        rank = { doc.id: doc.sim for doc in results.rank }
-        ids = [result.id for result in results.docs]
-
-        with Session(model.engine) as session:
-            docs = session.query(Document).filter(Document.id.in_(ids)).all()
-            docs = sorted(docs, key=lambda doc: rank[doc.id], reverse=True)
-
-            return { "query": q } | paginated(limit, offset, docs[offset:offset + limit], len(docs))
+        (docs, time) = timed(fetch_documents, q, dataset)
+        return { "query": q, "time": time } | paginated(limit, offset, docs[offset:offset + limit], len(docs))
             
     except Exception as e: # TODO: Remove this shitty exception handler by fixing empty results bug
         print(e)
-        return { "query": q } | paginated(limit, offset, [], 0)
+        return { "query": q, "time": 0 } | paginated(limit, offset, [], 0)

--- a/src/utils/timeit.py
+++ b/src/utils/timeit.py
@@ -1,0 +1,13 @@
+import time
+
+
+def timed(method, *args, **kwargs):
+    """
+    Get execution time for a method.
+    """
+    ts = time.time()
+    print("TS", ts)
+    result = method(*args, **kwargs)
+    te = time.time()
+    print("TE", te)
+    return (result, (te - ts) * 1000)


### PR DESCRIPTION
- feat: Add timeit util function
- feat: Timed fetch documents method
- feat: Send total of documents in response
- feat: Increase `max_length` of query results
